### PR TITLE
Stat handling updates

### DIFF
--- a/objects/oAbilityCaster/CleanUp_0.gml
+++ b/objects/oAbilityCaster/CleanUp_0.gml
@@ -4,5 +4,5 @@ instance_destroy(id_channelService);
 ds_list_destroy(list_effectsBuffer);
 ds_list_destroy(list_activeEffects);
 
-ds_map_destroy(map_baseStats);
-ds_map_destroy(map_currentStats);
+ds_map_destroy(map_stats);
+ds_map_destroy(map_frameStats);

--- a/objects/oAbilityCaster/Create_0.gml
+++ b/objects/oAbilityCaster/Create_0.gml
@@ -4,7 +4,8 @@ id_oneShotService = noone;
 id_channelService = noone;
 
 map_baseStats = StatsManager_GenerateEmptyStats();
-map_currentStats = StatsManager_GenerateEmptyStats();
+map_stats = StatsManager_GenerateEmptyStats();
+map_frameStats = StatsManager_GenerateEmptyStats();
 
 // Effects buffer list has entries of form:
 //		[enum_effect, arr_arguments, num_totalSteps]

--- a/objects/oAbilityCaster/Step_1.gml
+++ b/objects/oAbilityCaster/Step_1.gml
@@ -4,8 +4,8 @@ AbilityCaster_TICK_EFFECTS();
 // Add effects from buffer
 AbilityCaster_ADD_BUFFER_EFFECTS();
 
-// Reset current stats to base stats
-ds_map_copy(map_currentStats, map_baseStats);
+// Reset frame stats to stats
+ds_map_copy(map_frameStats, map_stats);
 
 //Apply effects to stats (mostly todo)
 AbilityCaster_APPLY_EFFECTS_TO_STATS();

--- a/objects/oMortal/Create_0.gml
+++ b/objects/oMortal/Create_0.gml
@@ -1,6 +1,5 @@
 event_inherited();
 
-num_maxHealth = 0;
 num_currentHealth = 0;
 
 list_damageList = ds_list_create(); //List containing arrays: [enum_damageType, num_damageAmount]

--- a/objects/oPlayer/Create_0.gml
+++ b/objects/oPlayer/Create_0.gml
@@ -1,5 +1,8 @@
 event_inherited();
-Mortal_Setup(10, true, true);
+
+var _map_baseStats = StatsManager_GenerateEmptyStats();
+_map_baseStats[? Enum_Stats.SPEED] = 3;
+Mortal_Setup(10, true, true, _map_baseStats);
 
 // Enumerable containing the movement modes that the player may utilise
 enum Enum_PlayerMoveModes {
@@ -9,8 +12,6 @@ enum Enum_PlayerMoveModes {
 }
 
 enum_currentMoveMode = Enum_PlayerMoveModes.FREEMOVE;	// Sets the default movement mode to FREEMOVE
-
-map_baseStats[? Enum_Stats.SPEED] = 3;
 
 // Dash
 num_dashSpeed = 10 / 3;

--- a/objects/oPlayer/Create_0.gml
+++ b/objects/oPlayer/Create_0.gml
@@ -2,7 +2,8 @@ event_inherited();
 
 var _map_baseStats = StatsManager_GenerateEmptyStats();
 _map_baseStats[? Enum_Stats.SPEED] = 3;
-Mortal_Setup(10, true, true, _map_baseStats);
+_map_baseStats[? Enum_Stats.HEALTH] = 10;
+Mortal_Setup(true, true, _map_baseStats);
 
 // Enumerable containing the movement modes that the player may utilise
 enum Enum_PlayerMoveModes {

--- a/scripts/AbilityCaster_Setup/AbilityCaster_Setup.gml
+++ b/scripts/AbilityCaster_Setup/AbilityCaster_Setup.gml
@@ -1,13 +1,19 @@
 #region Doc
-/// @function AbilityCaster_Setup(bool_hasOneShotService, bool_hasChannelService)
+/// @function AbilityCaster_Setup(bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {boolean} bool_hasOneShotService Whether the caster should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the caster should have a channel service.
+/// @param {map} map_baseStats The immutable base stats of the caster: map from stats to their values.
 #endregion
 var _bool_hasOneShotService = argument[0];
 var _bool_hasChannelService = argument[1];
+var _map_baseStats = argument[2];
 
 
 Collidable_Setup();
 
 id_oneShotService = _bool_hasOneShotService ? Service_Instantiate(id, oOneShotService) : noone;
 id_channelService = _bool_hasChannelService ? Service_Instantiate(id, oChannelService) : noone;
+
+ds_map_copy(map_baseStats, _map_baseStats);
+ds_map_copy(map_stats, map_baseStats); // TODO: hook into whatever system we'll use for setting stats
+                                       //       due to things like armor, passive effects etc.

--- a/scripts/AbilityCaster_Setup/AbilityCaster_Setup.gml
+++ b/scripts/AbilityCaster_Setup/AbilityCaster_Setup.gml
@@ -15,5 +15,6 @@ id_oneShotService = _bool_hasOneShotService ? Service_Instantiate(id, oOneShotSe
 id_channelService = _bool_hasChannelService ? Service_Instantiate(id, oChannelService) : noone;
 
 ds_map_copy(map_baseStats, _map_baseStats);
-ds_map_copy(map_stats, map_baseStats); // TODO: hook into whatever system we'll use for setting stats
-                                       //       due to things like armor, passive effects etc.
+ds_map_copy(map_stats, map_baseStats);    // TODO: Hook into whatever system we'll use for setting stats
+                                          //       due to things like armor, passive effects etc.
+ds_map_copy(map_frameStats, map_stats);   // To give stats on the ability casters first step.

--- a/scripts/Enemy_Setup/Enemy_Setup.gml
+++ b/scripts/Enemy_Setup/Enemy_Setup.gml
@@ -1,14 +1,12 @@
 #region Doc
-/// @function Enemy_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
-/// @param {number} num_maxHealth Max Health
+/// @function Enemy_Setup(bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {boolean} bool_hasOneShotService Whether the enemy should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the enemy should have a channel service.
 /// @param {map} map_baseStats The immutable base stats of the enemy: map from stats to their values.
 #endregion
-var _num_maxHealth = argument[0];
-var _bool_hasOneShotService = argument[1];
-var _bool_hasChannelService = argument[2];
-var _map_baseStats = argument[3];
+var _bool_hasOneShotService = argument[0];
+var _bool_hasChannelService = argument[1];
+var _map_baseStats = argument[2];
 
 
-NPC_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);
+NPC_Setup(_bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);

--- a/scripts/Enemy_Setup/Enemy_Setup.gml
+++ b/scripts/Enemy_Setup/Enemy_Setup.gml
@@ -1,12 +1,14 @@
 #region Doc
-/// @function Enemy_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService)
+/// @function Enemy_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {number} num_maxHealth Max Health
 /// @param {boolean} bool_hasOneShotService Whether the enemy should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the enemy should have a channel service.
+/// @param {map} map_baseStats The immutable base stats of the enemy: map from stats to their values.
 #endregion
 var _num_maxHealth = argument[0];
 var _bool_hasOneShotService = argument[1];
 var _bool_hasChannelService = argument[2];
+var _map_baseStats = argument[3];
 
 
-NPC_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService);
+NPC_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);

--- a/scripts/Friendly_Setup/Friendly_Setup.gml
+++ b/scripts/Friendly_Setup/Friendly_Setup.gml
@@ -1,12 +1,14 @@
 #region Doc
-/// @function Friendly_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService)
+/// @function Friendly_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {number} num_maxHealth Max Health
 /// @param {boolean} bool_hasOneShotService Whether the friendly object should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the friendly object should have a channel service.
+/// @param {map} map_baseStats The immutable base stats of the friendly: map from stats to their values.
 #endregion
 var _num_maxHealth = argument[0];
 var _bool_hasOneShotService = argument[1];
 var _bool_hasChannelService = argument[2];
+var _map_baseStats = argument[3];
 
 
-NPC_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService);
+NPC_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);

--- a/scripts/Friendly_Setup/Friendly_Setup.gml
+++ b/scripts/Friendly_Setup/Friendly_Setup.gml
@@ -1,14 +1,12 @@
 #region Doc
-/// @function Friendly_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
-/// @param {number} num_maxHealth Max Health
+/// @function Friendly_Setup(bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {boolean} bool_hasOneShotService Whether the friendly object should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the friendly object should have a channel service.
 /// @param {map} map_baseStats The immutable base stats of the friendly: map from stats to their values.
 #endregion
-var _num_maxHealth = argument[0];
-var _bool_hasOneShotService = argument[1];
-var _bool_hasChannelService = argument[2];
-var _map_baseStats = argument[3];
+var _bool_hasOneShotService = argument[0];
+var _bool_hasChannelService = argument[1];
+var _map_baseStats = argument[2];
 
 
-NPC_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);
+NPC_Setup(_bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);

--- a/scripts/Mortal_Setup/Mortal_Setup.gml
+++ b/scripts/Mortal_Setup/Mortal_Setup.gml
@@ -1,17 +1,19 @@
 #region Doc
-/// @function Mortal_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
-/// @param {number} num_maxHealth Max Health
+/// @function Mortal_Setup(bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {boolean} bool_hasOneShotService Whether the mortal object should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the mortal object should have a channel service.
 /// @param {map} map_baseStats The immutable base stats of the mortal: map from stats to their values.
 #endregion
-var _num_maxHealth = argument[0];
-var _bool_hasOneShotService = argument[1];
-var _bool_hasChannelService = argument[2];
-var _map_baseStats = argument[3];
+var _bool_hasOneShotService = argument[0];
+var _bool_hasChannelService = argument[1];
+var _map_baseStats = argument[2];
 
 
 AbilityCaster_Setup(_bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);
 
-num_maxHealth = _num_maxHealth;
-num_currentHealth = _num_maxHealth;
+var _num_health = StatsManager_GetHealth(id);
+if (_num_health <= 0) {
+	var _str_healthAsString = string(_num_health);
+	ErrorHandler_Error("Attempting to instantiate an oMortal with health <= 0, value was: " + _str_healthAsString);
+}
+num_currentHealth = _num_health;

--- a/scripts/Mortal_Setup/Mortal_Setup.gml
+++ b/scripts/Mortal_Setup/Mortal_Setup.gml
@@ -1,15 +1,17 @@
 #region Doc
-/// @function Mortal_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService)
+/// @function Mortal_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {number} num_maxHealth Max Health
 /// @param {boolean} bool_hasOneShotService Whether the mortal object should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the mortal object should have a channel service.
+/// @param {map} map_baseStats The immutable base stats of the mortal: map from stats to their values.
 #endregion
 var _num_maxHealth = argument[0];
 var _bool_hasOneShotService = argument[1];
 var _bool_hasChannelService = argument[2];
+var _map_baseStats = argument[3];
 
 
-AbilityCaster_Setup(_bool_hasOneShotService, _bool_hasChannelService);
+AbilityCaster_Setup(_bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);
 
 num_maxHealth = _num_maxHealth;
 num_currentHealth = _num_maxHealth;

--- a/scripts/NPC_Setup/NPC_Setup.gml
+++ b/scripts/NPC_Setup/NPC_Setup.gml
@@ -1,14 +1,12 @@
 #region Doc
-/// @function NPC_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
-/// @param {number} num_maxHealth Max Health
+/// @function NPC_Setup(bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {boolean} bool_hasOneShotService Whether the NPC should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the NPC should have a channel service.
 /// @param {map} map_baseStats The immutable base stats of the NPC: map from stats to their values.
 #endregion
-var _num_maxHealth = argument[0];
-var _bool_hasOneShotService = argument[1];
-var _bool_hasChannelService = argument[2];
-var _map_baseStats = argument[3];
+var _bool_hasOneShotService = argument[0];
+var _bool_hasChannelService = argument[1];
+var _map_baseStats = argument[2];
 
 
-Mortal_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);
+Mortal_Setup(_bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);

--- a/scripts/NPC_Setup/NPC_Setup.gml
+++ b/scripts/NPC_Setup/NPC_Setup.gml
@@ -1,12 +1,14 @@
 #region Doc
-/// @function NPC_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService)
+/// @function NPC_Setup(num_maxHealth, bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {number} num_maxHealth Max Health
 /// @param {boolean} bool_hasOneShotService Whether the NPC should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the NPC should have a channel service.
+/// @param {map} map_baseStats The immutable base stats of the NPC: map from stats to their values.
 #endregion
 var _num_maxHealth = argument[0];
 var _bool_hasOneShotService = argument[1];
 var _bool_hasChannelService = argument[2];
+var _map_baseStats = argument[3];
 
 
-Mortal_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService);
+Mortal_Setup(_num_maxHealth, _bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);

--- a/scripts/Passive_Setup/Passive_Setup.gml
+++ b/scripts/Passive_Setup/Passive_Setup.gml
@@ -1,10 +1,12 @@
 #region Doc
-/// @function Passive_Setup(bool_hasOneShotService, bool_hasChannelService)
+/// @function Passive_Setup(bool_hasOneShotService, bool_hasChannelService, map_baseStats)
 /// @param {boolean} bool_hasOneShotService Whether the passive object should have a one shot service.
 /// @param {boolean} bool_hasChannelService Whether the passive object should have a channel service.
+/// @param {map} map_baseStats The immutable base stats of the passive: map from stats to their values.
 #endregion
 var _bool_hasOneShotService = argument[0];
 var _bool_hasChannelService = argument[1];
+var _map_baseStats = argument[2];
 
 
-AbilityCaster_Setup(_bool_hasOneShotService, _bool_hasChannelService);
+AbilityCaster_Setup(_bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);

--- a/scripts/Passive_Setup/Passive_Setup.gml
+++ b/scripts/Passive_Setup/Passive_Setup.gml
@@ -10,3 +10,5 @@ var _map_baseStats = argument[2];
 
 
 AbilityCaster_Setup(_bool_hasOneShotService, _bool_hasChannelService, _map_baseStats);
+
+ds_map_destroy(_map_baseStats);

--- a/scripts/StatsManager_getHealth/StatsManager_getHealth.gml
+++ b/scripts/StatsManager_getHealth/StatsManager_getHealth.gml
@@ -11,4 +11,4 @@ if (!Utility_ObjectIsAncestorOfInstance(oAbilityCaster, _id_abilityCaster)) {
 	return noone;
 }
 
-return _id_abilityCaster.map_currentStats[? Enum_Stats.HEALTH];
+return _id_abilityCaster.map_frameStats[? Enum_Stats.HEALTH];

--- a/scripts/StatsManager_getSpeed/StatsManager_getSpeed.gml
+++ b/scripts/StatsManager_getSpeed/StatsManager_getSpeed.gml
@@ -11,4 +11,4 @@ if (!Utility_ObjectIsAncestorOfInstance(oAbilityCaster, _id_abilityCaster)) {
 	return noone;
 }
 
-return _id_abilityCaster.map_currentStats[? Enum_Stats.SPEED];
+return _id_abilityCaster.map_frameStats[? Enum_Stats.SPEED];


### PR DESCRIPTION
Didn't think we needed the script for setting stats in the end, as they all should get set by the base stats map that's passed through the set up scripts.

Each ability caster now passes a map of base stats through the setup scripts, this goes all the way up to the ability caster. Then each object back down can validate those stats, like the oMortal checking the health